### PR TITLE
shutters and mode for set room temperature + errorhandling

### DIFF
--- a/bin/max
+++ b/bin/max
@@ -90,10 +90,10 @@ sub do_dump {
 }
 
 sub do_set {
-    my ($room_id, $setpoint) = @_;
+    my ($room_id, $setpoint, $setmode) = @_;
     $room_id ||= 0;
 
-    my $usage = "Usage: $0 set <roomid> <temperature per 0.5>\n";
+    my $usage = "Usage: $0 set <roomid> <temperature per 0.5> <xx (optional mode 00=auto, 01=manual, 10=vacation, 11=boost)>\n";
     $room_id eq 'all' or _valid_uint8($room_id) && $room_id > 0 or die $usage;
     _valid_temperature($setpoint) or die $usage;
 
@@ -102,7 +102,7 @@ sub do_set {
     for my $room ($room_id eq 'all' ? $max->rooms : $max->room($room_id)) {
         $room->devices or warn "No devices in " . $room->display_name . ".\n";
         printf "Setting %s temperature to %s.\n", $room->display_name, $setpoint;
-        $room->setpoint($setpoint) or die "Setting temperature failed.\n";
+        $room->setpoint($setpoint, $setmode) or die "Setting temperature failed.\n";
     }
     print "Done.\n";
 }

--- a/bin/max
+++ b/bin/max
@@ -93,7 +93,7 @@ sub do_set {
     my ($room_id, $setpoint) = @_;
     $room_id ||= 0;
 
-    my $usage = "Usage: $0 manual <roomid> <temperature per 0.5>\n";
+    my $usage = "Usage: $0 set <roomid> <temperature per 0.5>\n";
     $room_id eq 'all' or _valid_uint8($room_id) && $room_id > 0 or die $usage;
     _valid_temperature($setpoint) or die $usage;
 

--- a/bin/max
+++ b/bin/max
@@ -120,19 +120,27 @@ sub do_status {
 
         for my $device (@devices) {
             next if $device->is_cube;
-            #next if $device->is_button;
+            next if $device->is_button;
             #next if $device->is_shutter;
-            if ( $device->is_shutter ) {
-            my $extra = 
-                sprintf("value is %d", $device->mode_num);
 
+            if ( $device->is_shutter ) {
+            my $extra;
+            if ( $device->mode_num == 0 ) {
+                    $extra = "closed   ";
+            } elsif ( $device->mode_num == 2 ) {
+                    $extra = "open     ";        
+            } else {
+                    $extra = "unknown value";
+            }
+            $extra = $extra . sprintf("(value is %d)", $device->mode_num);
             printf(
-                "    %-${width}s %s\n",
+                "    %-${width}s %s%s\n",
                 $device->display_name(1),
                 $extra,
                 uc $device->flags_as_string,
             );
             }
+
 
             if ( $device->has_setpoint ) {
                 my $setpoint = sprintf "%s@%.1f ", $device->mode, $device->setpoint

--- a/bin/max
+++ b/bin/max
@@ -121,47 +121,83 @@ sub do_status {
         printf "* %s\n", $room->display_name(1);
 
         for my $device (@devices) {
+            my $flags;
+            if( length($device->flags_as_string) == 0 ) {
+            $flags = "OK";
+            } else {
+            $flags = uc $device->flags_as_string;
+            }
+
             next if $device->is_cube;
             next if $device->is_button;
-            #next if $device->is_shutter;
 
             if ( $device->is_shutter ) {
-            my $extra;
-            if ( $device->mode_num == 0 ) {
-                    $extra = "closed   ";
-            } elsif ( $device->mode_num == 2 ) {
-                    $extra = "open     ";        
-            } else {
+                my $extra;
+                if ( $device->mode_num == 0 ) {
+                    $extra = "closed";
+                } elsif ( $device->mode_num == 2 ) {
+                    $extra = "open"; 
+                } else {
                     $extra = "unknown value";
-            }
-            $extra = $extra . sprintf("(value is %d)", $device->mode_num);
-            printf(
-                "    %-${width}s %s%s\n",
-                $device->display_name(1),
-                $extra,
-                uc $device->flags_as_string,
-            );
+                }
+                printf(
+                    "    %-${width}s %-13s %-15s %s\n",
+                    $device->display_name(1),
+                    $extra,
+                    sprintf("(value is %d)", $device->mode_num),
+                    $flags,
+                );
             }
 
             if ( $device->has_setpoint ) {
                 my $setpoint = sprintf "%s@%.1f ", $device->mode, $device->setpoint
-                    if $device->has_setpoint;
+                if $device->has_setpoint;
 
                 my $extra = 
-                    $device->has_temperature
-                    ? sprintf("(current %.1f) ", $device->temperature)
-                    : $device->has_valve
-                    ? sprintf("(valve at %d%%) ", $device->valve)
-                    : "";
-
+                $device->has_temperature
+                ? sprintf("(current %.1f)", $device->temperature)
+                : $device->has_valve
+                ? sprintf("(valve at %d%%)", $device->valve)
+                : ", ";
                 printf(
-                    "    %-${width}s %s%s%s\n",
+                    "    %-${width}s %-13s %-15s %s\n",
                     $device->display_name(1),
                     $setpoint,
                     $extra,
-                    uc $device->flags_as_string,
+                    $flags,
                 );
             }
+        }
+    }
+}
+
+sub do_batstatus {
+    $max ||= Max->connect($host);
+
+    my $width = max(map { length $_->display_name(1) } $max->devices);
+
+    for my $room ($max->rooms) {
+        my @devices = $room->devices;
+        next if @devices == 1 and $devices[0]->is_cube;
+
+        printf "* %s\n", $room->display_name(1);
+
+        for my $device (@devices) {
+        next if $device->is_cube;
+
+        my $batstat;
+        if ($device->flags_as_string =~ /battery/) {
+                        $batstat = "low";
+        } else {
+                        $batstat = "OK";
+        }
+
+        printf(
+            "    %-${width}s %s %s\n",
+            $device->display_name(1),
+            "BATTERYSTATUS:", 
+            $batstat,
+        );
         }
     }
 }

--- a/bin/max
+++ b/bin/max
@@ -100,6 +100,8 @@ sub do_set {
     $max ||= Max->connect($host);
 
     for my $room ($room_id eq 'all' ? $max->rooms : $max->room($room_id)) {
+        my @devices = $room->devices;
+        next if @devices == 1 and $devices[0]->is_cube;
         $room->devices or warn "No devices in " . $room->display_name . ".\n";
         printf "Setting %s temperature to %s.\n", $room->display_name, $setpoint;
         $room->setpoint($setpoint, $setmode) or die "Setting temperature failed.\n";
@@ -140,7 +142,6 @@ sub do_status {
                 uc $device->flags_as_string,
             );
             }
-
 
             if ( $device->has_setpoint ) {
                 my $setpoint = sprintf "%s@%.1f ", $device->mode, $device->setpoint

--- a/bin/max
+++ b/bin/max
@@ -120,6 +120,8 @@ sub do_status {
 
         for my $device (@devices) {
             next if $device->is_cube;
+            #next if $device->is_button;
+            #next if $device->is_shutter;
 
             my $setpoint = sprintf "%s@%.1f ", $device->mode, $device->setpoint
                 if $device->has_setpoint;

--- a/bin/max
+++ b/bin/max
@@ -122,24 +122,37 @@ sub do_status {
             next if $device->is_cube;
             #next if $device->is_button;
             #next if $device->is_shutter;
-
-            my $setpoint = sprintf "%s@%.1f ", $device->mode, $device->setpoint
-                if $device->has_setpoint;
-
+            if ( $device->is_shutter ) {
             my $extra = 
-                $device->has_temperature
-                ? sprintf("(current %.1f) ", $device->temperature)
-                : $device->has_valve
-                ? sprintf("(valve at %d%%) ", $device->valve)
-                : "";
+                sprintf("value is %d", $device->mode_num);
 
             printf(
-                "    %-${width}s %s%s%s\n",
+                "    %-${width}s %s\n",
                 $device->display_name(1),
-                $setpoint,
                 $extra,
                 uc $device->flags_as_string,
             );
+            }
+
+            if ( $device->has_setpoint ) {
+                my $setpoint = sprintf "%s@%.1f ", $device->mode, $device->setpoint
+                    if $device->has_setpoint;
+
+                my $extra = 
+                    $device->has_temperature
+                    ? sprintf("(current %.1f) ", $device->temperature)
+                    : $device->has_valve
+                    ? sprintf("(valve at %d%%) ", $device->valve)
+                    : "";
+
+                printf(
+                    "    %-${width}s %s%s%s\n",
+                    $device->display_name(1),
+                    $setpoint,
+                    $extra,
+                    uc $device->flags_as_string,
+                );
+            }
         }
     }
 }

--- a/bin/max.pod
+++ b/bin/max.pod
@@ -36,10 +36,11 @@ Outputs a debug dump of the internal state after conncting
 
 Initiates the pairing of a new device and configures the device's room id.
 
-=head3 set <room_id> <temperature>
+=head3 set <room_id> <temperature> <<mode>>
 
 Sends a new temperature to the devices in a room, forcing the mode to I<manual>.
 Specify C<all> instead of a numeric room ID to set the temperature everywhere.
+<<mode>> is optional. 00=auto, 01=manual, 10=vacation, 11=boost
 
 =head3 summary
 
@@ -70,6 +71,10 @@ Reboots the Cube.
 
 Can be set to the hostname or IPv4 address of the Cube to disable automatic
 discovery.
+
+=head3 MAX_DEFMODE
+
+Sets the Default mode <<mode>>, see set
 
 =head1 LICENSE
 

--- a/bin/max.pod
+++ b/bin/max.pod
@@ -46,6 +46,14 @@ Specify C<all> instead of a numeric room ID to set the temperature everywhere.
 
 Outputs a summary of device attributes, grouped by room.
 
+=head3 status
+
+Outputs some helpful device attributes for all devices except button and cube. 
+
+=head3 batstatus
+
+Outputs the battery status per devices, grouped by room.
+
 =head3 switch <command> [<on> <off>]
 
 Determines whether there is a demand for heat, and runs the given shell command

--- a/lib/Max.pm
+++ b/lib/Max.pm
@@ -123,58 +123,58 @@ sub _process_L {
             = unpack "a3 C n C C n C C", $devicedata;
         # button & shutter cause following output at next lines
         # Use of uninitialized value $setpoint in bitwise and (&) at /../lib/Max.pm line 126, <GEN0> line 8.
-        if (  defined $addr ) {
-print "addr-SET-1--~$addr~\n";
-}
-if (  defined $loff4unknown ) {
-print "loff4unknown-SET-1--~$loff4unknown~\n";
-}
-if (  defined $flags ) {
-print "flags-SET-1--~$flags~\n";
-}
-if (  defined $valve ) {
-print "valve-SET-1--~$valve~\n";
-}
-if (  defined $setpoint ) {
-print "setpoint-SET-1--~$setpoint~\n";
-}
-if (  defined $date ) {
-print "date-SET-1--~$date~\n";
-}
-if (  defined $time ) {
-print "time-SET-1--~$time~\n";
-}
-if (  defined $temp ) {
-print "temp-SET-1--~$temp~\n";
-}
+#if (  defined $addr ) {
+#print "addr-SET-1--~$addr~\n";
+#}
+#if (  defined $loff4unknown ) {
+#print "loff4unknown-SET-1--~$loff4unknown~\n";
+#}
+#if (  defined $flags ) {
+#print "flags-SET-1--~$flags~\n";
+#}
+#if (  defined $valve ) {
+#print "valve-SET-1--~$valve~\n";
+#}
+#if (  defined $setpoint ) {
+#print "setpoint-SET-1--~$setpoint~\n";
+#}
+#if (  defined $date ) {
+#print "date-SET-1--~$date~\n";
+#}
+#if (  defined $time ) {
+#print "time-SET-1--~$time~\n";
+#}
+#if (  defined $temp ) {
+#print "temp-SET-1--~$temp~\n";
+#}
 
 #        $temp |= !!($setpoint & 0x80) << 8;
 #        $setpoint &= 0x7F;
 
-if (  defined $addr ) {
-print "addr-SET-2--~$addr~\n";
-}
-if (  defined $loff4unknown ) {
-print "loff4unknown-SET-2--~$loff4unknown~\n";
-}
-if (  defined $flags ) {
-print "flags-SET-2--~$flags~\n";
-}
-if (  defined $valve ) {
-print "valve-SET-2--~$valve~\n";
-}
-if (  defined $setpoint ) {
-print "setpoint-SET-2--~$setpoint~\n";
-}
-if (  defined $date ) {
-print "date-SET-2--~$date~\n";
-}
-if (  defined $time ) {
-print "time-SET-2--~$time~\n";
-}
-if (  defined $temp ) {
-print "temp-SET-2--~$temp~\n";
-}
+#if (  defined $addr ) {
+#print "addr-SET-2--~$addr~\n";
+#}
+#if (  defined $loff4unknown ) {
+#print "loff4unknown-SET-2--~$loff4unknown~\n";
+#}
+#if (  defined $flags ) {
+#print "flags-SET-2--~$flags~\n";
+#}
+#if (  defined $valve ) {
+#print "valve-SET-2--~$valve~\n";
+#}
+#if (  defined $setpoint ) {
+#print "setpoint-SET-2--~$setpoint~\n";
+#}
+#if (  defined $date ) {
+#print "date-SET-2--~$date~\n";
+#}
+#if (  defined $time ) {
+#print "time-SET-2--~$time~\n";
+#}
+#if (  defined $temp ) {
+#print "temp-SET-2--~$temp~\n";
+#}
         my $device = $self->{devices}{$addr}
             or warn "Unexpected device " . unpack("H*", $addr);
 
@@ -186,22 +186,22 @@ print "temp-SET-2--~$temp~\n";
             invalid       => !  ($flags & 0x1000),
         });
 
-if ((  defined $valve ) && ( defined $setpoint )) {
-    $temp |= !!($setpoint & 0x80) << 8;
-    $setpoint &= 0x7F;
-    print "##################### VALVE and SETPOINT\n";
-    $device->_set(
-        mode        => $flags & 0x0003,
-        setpoint    => $setpoint / 2,
-        temperature => $temp / 10,
-        valve       => $valve,
-    )
-} else {
-    print "##################### JUST MODE\n";
-    $device->_set(
-        mode        => $flags & 0x0003,
-    )
-}
+        if ((  defined $valve ) && ( defined $setpoint )) {
+            $temp |= !!($setpoint & 0x80) << 8;
+            $setpoint &= 0x7F;
+            #print "##################### VALVE and SETPOINT\n";
+            $device->_set(
+                mode        => $flags & 0x0003,
+                setpoint    => $setpoint / 2,
+                temperature => $temp / 10,
+                valve       => $valve,
+            );
+        } else {
+            #print "##################### JUST MODE\n";
+            $device->_set(
+                mode        => $flags & 0x0003,
+            );
+        }
 #        $device->_set(
 #            mode        => $flags & 0x0003,
 #            setpoint    => $setpoint / 2,

--- a/lib/Max.pm
+++ b/lib/Max.pm
@@ -121,60 +121,7 @@ sub _process_L {
     for my $devicedata (@devices) {
         my ($addr, $loff4unknown, $flags, $valve, $setpoint, $date, $time, $temp)
             = unpack "a3 C n C C n C C", $devicedata;
-        # button & shutter cause following output at next lines
-        # Use of uninitialized value $setpoint in bitwise and (&) at /../lib/Max.pm line 126, <GEN0> line 8.
-#if (  defined $addr ) {
-#print "addr-SET-1--~$addr~\n";
-#}
-#if (  defined $loff4unknown ) {
-#print "loff4unknown-SET-1--~$loff4unknown~\n";
-#}
-#if (  defined $flags ) {
-#print "flags-SET-1--~$flags~\n";
-#}
-#if (  defined $valve ) {
-#print "valve-SET-1--~$valve~\n";
-#}
-#if (  defined $setpoint ) {
-#print "setpoint-SET-1--~$setpoint~\n";
-#}
-#if (  defined $date ) {
-#print "date-SET-1--~$date~\n";
-#}
-#if (  defined $time ) {
-#print "time-SET-1--~$time~\n";
-#}
-#if (  defined $temp ) {
-#print "temp-SET-1--~$temp~\n";
-#}
 
-#        $temp |= !!($setpoint & 0x80) << 8;
-#        $setpoint &= 0x7F;
-
-#if (  defined $addr ) {
-#print "addr-SET-2--~$addr~\n";
-#}
-#if (  defined $loff4unknown ) {
-#print "loff4unknown-SET-2--~$loff4unknown~\n";
-#}
-#if (  defined $flags ) {
-#print "flags-SET-2--~$flags~\n";
-#}
-#if (  defined $valve ) {
-#print "valve-SET-2--~$valve~\n";
-#}
-#if (  defined $setpoint ) {
-#print "setpoint-SET-2--~$setpoint~\n";
-#}
-#if (  defined $date ) {
-#print "date-SET-2--~$date~\n";
-#}
-#if (  defined $time ) {
-#print "time-SET-2--~$time~\n";
-#}
-#if (  defined $temp ) {
-#print "temp-SET-2--~$temp~\n";
-#}
         my $device = $self->{devices}{$addr}
             or warn "Unexpected device " . unpack("H*", $addr);
 
@@ -189,7 +136,6 @@ sub _process_L {
         if ((  defined $valve ) && ( defined $setpoint )) {
             $temp |= !!($setpoint & 0x80) << 8;
             $setpoint &= 0x7F;
-            #print "##################### VALVE and SETPOINT\n";
             $device->_set(
                 mode        => $flags & 0x0003,
                 setpoint    => $setpoint / 2,
@@ -197,17 +143,10 @@ sub _process_L {
                 valve       => $valve,
             );
         } else {
-            #print "##################### JUST MODE\n";
             $device->_set(
                 mode        => $flags & 0x0003,
             );
         }
-#        $device->_set(
-#            mode        => $flags & 0x0003,
-#            setpoint    => $setpoint / 2,
-#            temperature => $temp / 10,
-#            valve       => $valve,
-#        ) if defined $setpoint;  # not for button/shutter
     }
 }
 

--- a/lib/Max.pm
+++ b/lib/Max.pm
@@ -119,13 +119,62 @@ sub _process_L {
     my $data = decode_base64 $base64;
     my @devices = unpack "(C/a)*", $data;
     for my $devicedata (@devices) {
-        my ($addr, undef, $flags, $valve, $setpoint, $date, $time, $temp)
+        my ($addr, $loff4unknown, $flags, $valve, $setpoint, $date, $time, $temp)
             = unpack "a3 C n C C n C C", $devicedata;
         # button & shutter cause following output at next lines
         # Use of uninitialized value $setpoint in bitwise and (&) at /../lib/Max.pm line 126, <GEN0> line 8.
+        if (  defined $addr ) {
+print "addr-SET-1--~$addr~\n";
+}
+if (  defined $loff4unknown ) {
+print "loff4unknown-SET-1--~$loff4unknown~\n";
+}
+if (  defined $flags ) {
+print "flags-SET-1--~$flags~\n";
+}
+if (  defined $valve ) {
+print "valve-SET-1--~$valve~\n";
+}
+if (  defined $setpoint ) {
+print "setpoint-SET-1--~$setpoint~\n";
+}
+if (  defined $date ) {
+print "date-SET-1--~$date~\n";
+}
+if (  defined $time ) {
+print "time-SET-1--~$time~\n";
+}
+if (  defined $temp ) {
+print "temp-SET-1--~$temp~\n";
+}
+
         $temp |= !!($setpoint & 0x80) << 8;
         $setpoint &= 0x7F;
 
+if (  defined $addr ) {
+print "addr-SET-2--~$addr~\n";
+}
+if (  defined $loff4unknown ) {
+print "loff4unknown-SET-2--~$loff4unknown~\n";
+}
+if (  defined $flags ) {
+print "flags-SET-2--~$flags~\n";
+}
+if (  defined $valve ) {
+print "valve-SET-2--~$valve~\n";
+}
+if (  defined $setpoint ) {
+print "setpoint-SET-2--~$setpoint~\n";
+}
+if (  defined $date ) {
+print "date-SET-2--~$date~\n";
+}
+if (  defined $time ) {
+print "time-SET-2--~$time~\n";
+}
+if (  defined $temp ) {
+print "temp-SET-2--~$temp~\n";
+}
         my $device = $self->{devices}{$addr}
             or warn "Unexpected device " . unpack("H*", $addr);
 

--- a/lib/Max.pm
+++ b/lib/Max.pm
@@ -148,8 +148,8 @@ if (  defined $temp ) {
 print "temp-SET-1--~$temp~\n";
 }
 
-        $temp |= !!($setpoint & 0x80) << 8;
-        $setpoint &= 0x7F;
+#        $temp |= !!($setpoint & 0x80) << 8;
+#        $setpoint &= 0x7F;
 
 if (  defined $addr ) {
 print "addr-SET-2--~$addr~\n";
@@ -186,12 +186,28 @@ print "temp-SET-2--~$temp~\n";
             invalid       => !  ($flags & 0x1000),
         });
 
-        $device->_set(
-            mode        => $flags & 0x0003,
-            setpoint    => $setpoint / 2,
-            temperature => $temp / 10,
-            valve       => $valve,
-        ) if defined $setpoint;  # not for button/shutter
+if ((  defined $valve ) && ( defined $setpoint )) {
+    $temp |= !!($setpoint & 0x80) << 8;
+    $setpoint &= 0x7F;
+    print "##################### VALVE and SETPOINT\n";
+    $device->_set(
+        mode        => $flags & 0x0003,
+        setpoint    => $setpoint / 2,
+        temperature => $temp / 10,
+        valve       => $valve,
+    )
+} else {
+    print "##################### JUST MODE\n";
+    $device->_set(
+        mode        => $flags & 0x0003,
+    )
+}
+#        $device->_set(
+#            mode        => $flags & 0x0003,
+#            setpoint    => $setpoint / 2,
+#            temperature => $temp / 10,
+#            valve       => $valve,
+#        ) if defined $setpoint;  # not for button/shutter
     }
 }
 

--- a/lib/Max.pm
+++ b/lib/Max.pm
@@ -122,7 +122,7 @@ sub _process_L {
         my ($addr, undef, $flags, $valve, $setpoint, $date, $time, $temp)
             = unpack "a3 C n C C n C C", $devicedata;
         # button & shutter cause following output at next lines
-        # Use of uninitialized value $setpoint in bitwise and (&) at /../lib/Max.pm line 129, <GEN0> line 8.
+        # Use of uninitialized value $setpoint in bitwise and (&) at /../lib/Max.pm line 126, <GEN0> line 8.
         $temp |= !!($setpoint & 0x80) << 8;
         $setpoint &= 0x7F;
 

--- a/lib/Max.pm
+++ b/lib/Max.pm
@@ -121,7 +121,8 @@ sub _process_L {
     for my $devicedata (@devices) {
         my ($addr, undef, $flags, $valve, $setpoint, $date, $time, $temp)
             = unpack "a3 C n C C n C C", $devicedata;
-
+        # button & shutter cause following output at next lines
+        # Use of uninitialized value $setpoint in bitwise and (&) at /../lib/Max.pm line 129, <GEN0> line 8.
         $temp |= !!($setpoint & 0x80) << 8;
         $setpoint &= 0x7F;
 

--- a/lib/Max/Device.pm
+++ b/lib/Max/Device.pm
@@ -68,6 +68,8 @@ sub is_cube         { $_[0]->{type} == 0 }
 sub has_valve       { $_[0]->{type} == 1 or $_[0]->{type} == 2 }
 sub has_temperature { $_[0]->{type} == 3 }
 sub has_setpoint    { $_[0]->{type} >= 1 and $_[0]->{type} <= 3 }
+sub is_shutter      { $_[0]->{type} == 4 }
+sub is_button       { $_[0]->{type} == 5 }
 
 sub room {
     my ($self, $new) = @_;

--- a/lib/Max/Device.pod
+++ b/lib/Max/Device.pod
@@ -151,7 +151,7 @@ Note: not all devices have a valve. Use C<has_valve> to test this.
 
 =over
 
-=item * Shutter and button devices are not (yet) supported.
+=item * Shutter and button devices are not (yet) really supported.
 
 =item * Tricks exist to read the current measured temperature from a TRV, but
 because that involves waiting for parameters to change, this library does not

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -4,6 +4,8 @@ package Max::Room;
 use Carp qw(croak carp);
 use MIME::Base64 qw(decode_base64 encode_base64);
 
+my $defmode = "00";
+
 sub new {
     my ($class, %p) = @_;
     $p{devices} ||= {};
@@ -78,7 +80,7 @@ sub setpoint {
     ($t2 == int $t2) or croak "Temperature not a multiple of 0.5";
     $t2 > 0 or $t2 < 256 or croak "Invalid temperature ($new)";
     # Set Mode 00=auto, 01=manual, 10=vacation, 11=boost
-    my $tempmode = sprintf("00");
+    my $tempmode = $defmode;
     # Calc Temperature
     my $tempbin = sprintf("%b",$t2);
     # Combine Mode & Temperature to hex

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -4,7 +4,14 @@ package Max::Room;
 use Carp qw(croak carp);
 use MIME::Base64 qw(decode_base64 encode_base64);
 
-my $defmode = "00";
+my $defmode;
+$defmode = $ENV{MAX_DEFMODE};
+if(!defined $defmode || length($defmode) == 0)
+{
+    # MAX_DEFMODE is unset so hardcode value
+    # Set Mode 00=auto, 01=manual, 10=vacation, 11=boost
+    $defmode = "00";
+}
 
 sub new {
     my ($class, %p) = @_;

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -94,6 +94,18 @@ sub setpoint {
     } else {
     $tempmode = $setmode;
     }
+    if ( $setmode eq '00' || lc($setmode) eq 'auto' ) {
+    	$tempmode = '00';
+    } elsif ( $setmode eq '01' || lc($setmode) eq 'manual' || lc($setmode) eq 'party' ) {
+    	$tempmode = '01';
+    } elsif ( $setmode eq '10' || lc($setmode) eq 'vacation' ) {
+    	$tempmode = '10';
+    } elsif ( $setmode eq '11' || lc($setmode) eq 'boost' ) {
+    	$tempmode = '11';
+    } else {
+        $tempmode = $defmode;
+    }
+
 
     # Calc Temperature
     my $tempbin = sprintf("%06b",$t2);

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -77,8 +77,14 @@ sub setpoint {
     my $t2 = $new * 2;
     ($t2 == int $t2) or croak "Temperature not a multiple of 0.5";
     $t2 > 0 or $t2 < 256 or croak "Invalid temperature ($new)";
-
-    return $self->_send_radio(0x40, sprintf "%02x", $t2 | 0x40);
+    #Set Mode 
+    my $tempmode = sprintf("00");
+    #Calc Temperature
+    my $tempbin = sprintf("%b",$t2);
+    # Combine Mode & Temperature to hex
+    my $tempsendhex = sprintf('%x', oct("0b$tempmode$tempbin"));
+    # Send combined hex 
+    return $self->_send_radio(0x40, $tempsendhex);
 }
 
 sub too_cold {

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -94,19 +94,17 @@ sub setpoint {
     } else {
     $tempmode = $setmode;
     }
-    if ( $setmode eq '00' || lc($setmode) eq 'auto' ) {
-    	$tempmode = '00';
-    } elsif ( $setmode eq '01' || lc($setmode) eq 'manual' || lc($setmode) eq 'party' ) {
-    	$tempmode = '01';
-    } elsif ( $setmode eq '10' || lc($setmode) eq 'vacation' ) {
-    	$tempmode = '10';
-    } elsif ( $setmode eq '11' || lc($setmode) eq 'boost' ) {
-    	$tempmode = '11';
+    if ( $setmode eq '00' || lc($setmode) =~ m/^aut/ ) {
+        $tempmode = '00';
+    } elsif ( $setmode eq '01' || lc($setmode) =~ m/^man/ || lc($setmode) =~ m/^par/ ) {
+        $tempmode = '01';
+    } elsif ( $setmode eq '10' || lc($setmode)  =~ m/^vac/ ) {
+        $tempmode = '10';
+    } elsif ( $setmode eq '11' || lc($setmode)  =~ m/^boo/ ) {
+        $tempmode = '11';
     } else {
         $tempmode = $defmode;
     }
-
-
     # Calc Temperature
     my $tempbin = sprintf("%06b",$t2);
     # Combine Mode & Temperature to hex

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -73,7 +73,8 @@ sub _get_setpoint {
 
     for my $device ($self->devices) {
         # TRVs sometimes report setpoint as 0.0
-        return $device->setpoint if $device->setpoint > 0;
+        # return $device->setpoint if $device->setpoint > 0;
+        return $device->setpoint if (( defined $device->setpoint ) && ( $device->setpoint > 0 ));
     }
     return undef;
 }

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -77,7 +77,7 @@ sub setpoint {
     my $t2 = $new * 2;
     ($t2 == int $t2) or croak "Temperature not a multiple of 0.5";
     $t2 > 0 or $t2 < 256 or croak "Invalid temperature ($new)";
-    #Set Mode 
+    #Set Mode 00=auto, 01=manual, 10=vacation, 11=boost
     my $tempmode = sprintf("00");
     #Calc Temperature
     my $tempbin = sprintf("%b",$t2);

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -82,9 +82,9 @@ sub setpoint {
     # Set Mode 00=auto, 01=manual, 10=vacation, 11=boost
     my $tempmode = $defmode;
     # Calc Temperature
-    my $tempbin = sprintf("%b",$t2);
+    my $tempbin = sprintf("%06b",$t2);
     # Combine Mode & Temperature to hex
-    my $tempsendhex = sprintf('%x', oct("0b$tempmode$tempbin"));
+    my $tempsendhex = sprintf('%02x', oct("0b$tempmode$tempbin"));
     # Send combined hex 
     return $self->_send_radio(0x40, $tempsendhex);
 }

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -79,7 +79,7 @@ sub _get_setpoint {
 }
 
 sub setpoint {
-    my ($self, $new) = @_;
+    my ($self, $new, $setmode) = @_;
 
     return $self->_get_setpoint if not defined $new;
 
@@ -87,7 +87,14 @@ sub setpoint {
     ($t2 == int $t2) or croak "Temperature not a multiple of 0.5";
     $t2 > 0 or $t2 < 256 or croak "Invalid temperature ($new)";
     # Set Mode 00=auto, 01=manual, 10=vacation, 11=boost
-    my $tempmode = $defmode;
+    my $tempmode;
+    if(!defined $setmode || length($setmode) == 0)
+    {
+    $tempmode = $defmode;
+    } else {
+    $tempmode = $setmode;
+    }
+
     # Calc Temperature
     my $tempbin = sprintf("%06b",$t2);
     # Combine Mode & Temperature to hex

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -73,7 +73,6 @@ sub _get_setpoint {
 
     for my $device ($self->devices) {
         # TRVs sometimes report setpoint as 0.0
-        # return $device->setpoint if $device->setpoint > 0;
         return $device->setpoint if (( defined $device->setpoint ) && ( $device->setpoint > 0 ));
     }
     return undef;

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -90,10 +90,8 @@ sub setpoint {
     my $tempmode;
     if(!defined $setmode || length($setmode) == 0)
     {
-    $tempmode = $defmode;
-    } else {
-    $tempmode = $setmode;
-    }
+    $setmode = $defmode;
+    } 
     if ( $setmode eq '00' || lc($setmode) =~ m/^aut/ ) {
         $tempmode = '00';
     } elsif ( $setmode eq '01' || lc($setmode) =~ m/^man/ || lc($setmode) =~ m/^par/ ) {

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -77,9 +77,9 @@ sub setpoint {
     my $t2 = $new * 2;
     ($t2 == int $t2) or croak "Temperature not a multiple of 0.5";
     $t2 > 0 or $t2 < 256 or croak "Invalid temperature ($new)";
-    #Set Mode 00=auto, 01=manual, 10=vacation, 11=boost
+    # Set Mode 00=auto, 01=manual, 10=vacation, 11=boost
     my $tempmode = sprintf("00");
-    #Calc Temperature
+    # Calc Temperature
     my $tempbin = sprintf("%b",$t2);
     # Combine Mode & Temperature to hex
     my $tempsendhex = sprintf('%x', oct("0b$tempmode$tempbin"));

--- a/lib/Max/Room.pod
+++ b/lib/Max/Room.pod
@@ -61,8 +61,9 @@ Returns undef if the setting is not known.
 
 =head3 setpoint($temperature)
 
-Sends a new B<manual> setpoint temperature to all the devices in the room. The
-new temperature must be a multiple of 0.5.
+Sends a new B<mode> setpoint temperature to all the devices in the room. The
+new temperature must be a multiple of 0.5. 
+The B<mode> can be set to 00=auto, 01=manual, 10=vacation, 11=boost. 
 
 Currently does not handle errors.
 
@@ -83,8 +84,8 @@ temperature or setpoint is not known.
 
 =item * Very little parameter checking is done.
 
-=item * Because C<set_temperature> sets the mode to "manual", the setting is
-kept. The suggested use of this library is to set programs on a computer (via
+=item * If the C<set_temperature> sets the mode to "manual", the setting is
+kept. The suggested use of this library is then to set programs on a computer (via
 cron) rather than directly on the devices.
 
 =back


### PR DESCRIPTION
Maybe it's useful.
My Perl knowledge is limited so that the Code changes doesn't look pretty but previous tests were successful and it works for me. All just tested with the executable max. I just Changed parts of the Perl modules. 

The request contains:
- use of `<mode>` for set room temperature 
	- mode input as text or number value: 00 or auto, 01 or manual, 10 or vacation, 11 or boost
	- new environment variable MAX_DEFMODE for Default `<mode>`
- output of shutters and those values within do_status
- added do_batstatus
- some,  more or less error handling

fixed: ~~With every start Shutters and probably Buttons still cause errors like:~~ 
```
Use of uninitialized value $setpoint in bitwise and (&) at /opt/eq3-max-master/bin/../lib/Max.pm line 127, <GEN0> line 8.
Use of uninitialized value $setpoint in bitwise and (&) at /opt/eq3-max-master/bin/../lib/Max.pm line 128, <GEN0> line 8.
```

~~They are probably caused by the lines:~~ Lines were in the wrong order
```
$temp |= !!($setpoint & 0x80) << 8;
$setpoint &= 0x7F;
```
~~At the moment i don't have a quick fix for that. Works anyway.~~ fixed.

best regards, 
Sebastian

Edited the further progress. 
second Pull request from branch "deb_process_L" and nor my master
