### PR TITLE
Fixing window sensor printf error (#10)

### DIFF
--- a/bin/max
+++ b/bin/max
@@ -134,7 +134,8 @@ sub do_status {
         for my $device (@devices) {
             next if $device->is_cube;
 
-            my $setpoint = sprintf "%s@%.1f ", $device->mode, $device->setpoint
+            my $setpoint = "";
+            $setpoint = sprintf "%s@%.1f ", $device->mode, $device->setpoint
                 if $device->has_setpoint;
 
             my $extra = 


### PR DESCRIPTION
Without this change I get

> Use of uninitialized value $setpoint in printf at /usr/local/bin/max line 147, <GEN0> line 18.

![image](https://user-images.githubusercontent.com/503702/136356262-b85092bd-f70e-43a8-959a-ec77565cd3fe.png)
