### PR TITLE
MQTT improvements

### DIFF
--- a/bin/max
+++ b/bin/max
@@ -294,7 +294,10 @@ sub do_mqtt {
     require Net::MQTT::Simple;
     my $hostname = shift;
     my $topic_prefix = shift;
+    my $username = shift;
+    my $password = shift;
     our $mqtt ||= Net::MQTT::Simple->new($hostname);
+    $mqtt->login($username, $password) if $username and $password;
 
     for my $room ($max->rooms) {
         my @devices = $room->devices;
@@ -303,16 +306,25 @@ sub do_mqtt {
         for my $device (@devices) {
             my $r = $room->display_name;
             my $d = $device->display_name;
-            s/\ /-/g for $r, $d;
+            s/\W+/-/g for $r, $d;
             my $devtopic = join "/", $topic_prefix, $r, $d;
             my $c = "°C";
             utf8::encode($c);
             $mqtt->retain("$devtopic/valve", $device->valve . " %")
                 if $device->has_valve;
+            $mqtt->retain("$devtopic/valve_perc", $device->valve)
+                if $device->has_valve;
             $mqtt->retain("$devtopic/setpoint", $device->setpoint . " $c")
+                if $device->has_setpoint;
+            $mqtt->retain("$devtopic/setpoint_c", $device->setpoint)
                 if $device->has_setpoint;
             $mqtt->retain("$devtopic/temperature", $device->temperature . " $c")
                 if $device->has_temperature;
+            $mqtt->retain("$devtopic/temperature_c", $device->temperature)
+                if $device->has_temperature;
+            while( my ($flag, $value) = each %{$device->{flags}} ) {
+                $mqtt->retain("$devtopic/flag_$flag", $value ? 1 : 0);
+            }
         }
     }
 }

--- a/bin/max.pod
+++ b/bin/max.pod
@@ -84,11 +84,14 @@ Outputs a list of rooms with values from the room's devices.
 
 Outputs a summary of device attributes, grouped by room.
 
-=head3 mqtt <hostname> <topic_prefix>
+=head3 mqtt <hostname> <topic_prefix> <username> <password>
 
 Publishes device attributes to the given MQTT server. Currently does not
-support any authentication or TLS. The I<topic_prefix> should not end in C</>,
-as one is added by the program.
+support TLS. The I<topic_prefix> should not end in C</>, as one is added by the
+program.
+
+Username and password are optional. If they are specified, you probably also
+want to add the C<MQTT_SIMPLE_ALLOW_INSECURE_LOGIN=1> environment variable.
 
 The messages are sent with the I<retain> flag enabled, and consist of the
 numeric decimal value, a space, and the corresponding unit.


### PR DESCRIPTION
- The "+" symbol in heater+ caused mosquitto to reject all messages
- Create plain number values with type specified in the topic name for easier parsing
- Add in flags to detect eg low battery issues