### PR TITLE
Prevent crash from corrupt thermostat record

### DIFF
--- a/bin/max
+++ b/bin/max
@@ -102,10 +102,10 @@ sub do_set {
     my ($room_id, $setpoint) = @_;
     $room_id ||= 0;
 
-    my $usage = "Usage: $0 set <roomid> <eco|comfort|temperature per 0.5>\n";
+    my $usage = "Usage: $0 set <roomid> <boost|eco|comfort|temperature per 0.5>\n";
     $room_id eq 'all' or _valid_uint8($room_id) && $room_id > 0 or die $usage;
 
-    $setpoint eq 'eco' or $setpoint eq 'comfort'
+    $setpoint eq 'eco' or $setpoint eq 'comfort' or $setpoint eq 'boost'
         or _valid_temperature($setpoint) or die $usage;
 
     $max ||= Max->connect($host);
@@ -114,7 +114,11 @@ sub do_set {
         $room->devices or warn "No devices in " . $room->display_name . ".\n";
         my $t = $setpoint =~ /eco|comfort/ ? $room->get_preset($setpoint) : $setpoint;
         printf "Setting %s temperature to %s.\n", $room->display_name, $t;
-        $room->setpoint($t) or die "Setting temperature failed.\n";
+        if($setpoint eq 'boost'){
+           $room->boost() or die "Boosting temperature failed.\n";
+        }else{
+           $room->setpoint($t) or die "Setting temperature failed.\n";
+        }
     }
     print "Done.\n";
 }

--- a/bin/max
+++ b/bin/max
@@ -119,6 +119,23 @@ sub do_set {
     print "Done.\n";
 }
 
+sub do_boost {
+    my ($room_id) = @_;
+    $room_id ||= 0;
+
+    my $usage = "Usage: $0 boost <roomid>\n";
+    $room_id eq 'all' or _valid_uint8($room_id) && $room_id > 0 or die $usage;
+
+    $max ||= Max->connect($host);
+
+    for my $room ($room_id eq 'all' ? $max->rooms : $max->room($room_id)) {
+        $room->devices or warn "No devices in " . $room->display_name . ".\n";
+        printf "Boosting %s.\n", $room->display_name;
+        $room->boost() or die "Boosting temperature failed.\n";
+    }
+    print "Done.\n";
+}
+
 sub do_status {
     $max ||= Max->connect($host);
     clear;

--- a/lib/Max.pm
+++ b/lib/Max.pm
@@ -126,26 +126,28 @@ sub _process_L {
         my $device = $self->{devices}{$addr}
             or warn "Unexpected device " . unpack("H*", $addr);
 
-        $device->_set(flags => {
-            link_error    => !! ($flags & 0x0040),
-            battery       => !! ($flags & 0x0080),
-            uninitialized => !  ($flags & 0x0200),
-            error         => !! ($flags & 0x0800),
-            invalid       => !  ($flags & 0x1000),
-        });
+        if (defined $device) {
+            $device->_set(flags => {
+                link_error    => !! ($flags & 0x0040),
+                battery       => !! ($flags & 0x0080),
+                uninitialized => !  ($flags & 0x0200),
+                error         => !! ($flags & 0x0800),
+                invalid       => !  ($flags & 0x1000),
+            });
 
-        if (defined $setpoint) {  # not for button/shutter
-            $temp |= !!($setpoint & 0x80) << 8;
-            $setpoint &= 0x7F;
+            if (defined $setpoint) {  # not for button/shutter
+                $temp |= !!($setpoint & 0x80) << 8;
+                $setpoint &= 0x7F;
 
-            $temp = $date if $temp == 0 and $date > 0 and $device->has_temperature;
+                $temp = $date if $temp == 0 and $date > 0 and $device->has_temperature;
 
-            $device->_set(
-                mode        => $flags & 0x0003,
-                setpoint    => $setpoint / 2,
-                temperature => $temp / 10,
-                valve       => $valve,
-            );
+                $device->_set(
+                    mode        => $flags & 0x0003,
+                    setpoint    => $setpoint / 2,
+                    temperature => $temp / 10,
+                    valve       => $valve,
+                );
+            }
         }
     }
 }

--- a/lib/Max/Room.pm
+++ b/lib/Max/Room.pm
@@ -94,6 +94,12 @@ sub setpoint {
     return $self->_send_radio(0x40, sprintf "%02x", $t2 | 0x40);
 }
 
+sub boost {
+    my ($self) = @_;
+    my $t2 = $self->_get_setpoint * 2;
+    return $self->_send_radio(0x40, sprintf "%02x", $t2 | 0xc0);   
+}
+
 sub too_cold {
     my ($self, $maxdelta) = @_;
     $maxdelta ||= 0;


### PR DESCRIPTION
The cube is unstable (i understand) and so its possible for `max` to stop working when this happens, boiler control will stop and things can get a little frosty ;)

output might be like

```
$ ~/workspace/eq3/eq3-max/bin/max 
Found cube at 192.168.10.145
Unexpected device 0cfb4d at /home/rdlb/workspace/eq3/eq3-max/bin/../lib/Max.pm line 126, <GEN2> line 7.
Can't call method "_set" on an undefined value at /home/rdlb/workspace/eq3/eq3-max/bin/../lib/Max.pm line 129, <GEN2> line 7.

```
even forgetting the device cant work

```
$ ~/workspace/eq3/eq3-max/bin/max forget 0cfb4d
Found cube at 192.168.10.145
Unexpected device 0cfb4d at /home/rdlb/workspace/eq3/eq3-max/bin/../lib/Max.pm line 126, <GEN2> line 7.
Can't call method "_set" on an undefined value at /home/rdlb/workspace/eq3/eq3-max/bin/../lib/Max.pm line 129, <GEN2> line 7

```


this PR simply guards against this undefined $device

and even though it looks like things are not good, the device can then be forgotten and things recover

```
$ ~/workspace/eq3/eq3-max/bin/max forget 0cfb4d
Found cube at 192.168.10.145
Unexpected device 0cfb4d at /home/rdlb/workspace/eq3/eq3-max/bin/../lib/Max.pm line 126, <GEN2> line 7.
Unexpected device 0ad98d at /home/rdlb/workspace/eq3/eq3-max/bin/../lib/Max.pm line 126, <GEN2> line 7.
Unexpected device 09ed2a at /home/rdlb/workspace/eq3/eq3-max/bin/../lib/Max.pm line 126, <GEN2> line 7.
Unexpected device 0bda40 at /home/rdlb/workspace/eq3/eq3-max/bin/../lib/Max.pm line 126, <GEN2> line 7.
Unexpected device 0bda32 at /home/rdlb/workspace/eq3/eq3-max/bin/../lib/Max.pm line 126, <GEN2> line 7.
Unexpected device 09ed35 at /home/rdlb/workspace/eq3/eq3-max/bin/../lib/Max.pm line 126, <GEN2> line 7.
Unexpected device 0bef2a at /home/rdlb/workspace/eq3/eq3-max/bin/../lib/Max.pm line 126, <GEN2> line 7.
Done.

$ ~/workspace/eq3/eq3-max/bin/max 
Found cube at 192.168.10.145
* Kitchen(1)         0.0 →  0.0   
* TV(2)              0.0 → 21.5    74%
* Conservatory(3)   18.2 → 19.5    65%
* Tech Room(4)       0.0 → 19.0     0%
* Hall(5)           20.0 → 20.5    25%
* Bedroom 2(6) 19.6 → 19.0    13%
* Bathroom(7)       18.6 → 19.5    20%
* Bedroom(8)         0.0 → 19.0     0%
* Office(9)     0.0 → 18.5     0%
* Loft(10)           0.0 → 18.0     0%

```